### PR TITLE
Fix invalid project-id and invalid occurrence issue

### DIFF
--- a/example/v1alpha1/README.md
+++ b/example/v1alpha1/README.md
@@ -6,4 +6,9 @@ To run this server against the Grafeas reference implementation run the followin
 go get github.com/Grafeas/Greafeas/samples/server/go-server/api/
 go get github.com/Grafeas/client-go
 go run grafeas/samples/server/go-server/api/server/main/main.go
+
+# v1alpha1 client-go example relies on the existence of project "best-vuln-scanner"
+# Use the following curl command to create the project "best-vuln-scanner"
+curl -H "Accept: application/json" -H "Content-type: application/json" -d "{\"name\":\"projects/best-vuln-scanner\"}" -X POST  http://localhost:8080/v1alpha1/projects
+
 go run client-go/example/v1alpha1/main.go

--- a/example/v1alpha1/main.go
+++ b/example/v1alpha1/main.go
@@ -41,7 +41,8 @@ func main() {
 	}
 
 	oPID := "scanning-customer"
-	o := Occurrence(createdN.Name)
+	o := Occurrence(createdN.Name, fmt.Sprintf("projects/%v/occurrences/%v", nPID, oPID))
+
 	createdO, _, err := client.CreateOccurrence(oPID, *o)
 	if err != nil {
 		log.Fatalf("Error creating occurrence %v", err)
@@ -51,9 +52,10 @@ func main() {
 
 	_, oID, pErr := name.ParseOccurrence(createdO.Name)
 	if pErr != nil {
-		log.Fatalf("Unable to get occurenceId from occurrence name %v: %v", createdO.Name, err)
+		log.Fatalf("Unable to get occurenceId from occurrence name %v: %v", createdO.Name, pErr)
 	}
-	if got, _, err := client.GetOccurrence(oPID, oID); err != nil {
+
+	if got, _, err := client.GetOccurrence(nPID, oID); err != nil {
 		log.Printf("Error getting occurrence %v", err)
 	} else {
 		log.Printf("Succesfully got occurrence: %v", got)
@@ -165,8 +167,10 @@ func note(pID, nID string) *v1alpha1.Note {
 	}
 }
 
-func Occurrence(noteName string) *v1alpha1.Occurrence {
+/* Specify occurrence instead of using default value of empty string */
+func Occurrence(noteName, occurrenceName string) *v1alpha1.Occurrence {
 	return &v1alpha1.Occurrence{
+		Name:             occurrenceName,
 		ResourceUrl: "gcr.io/foo/bar",
 		NoteName:    noteName,
 		Kind:        "PACKAGE_VULNERABILITY",


### PR DESCRIPTION
1. The client code assumes the existence of the project "best-vuln-scanner". Since project creation is not a part of Grafeas Client API now, README.md file was updated to include the curl command to create the project via POST. Otherwise "Project best-vuln-scanner does not exist" would be seen on server side and client side would print note and occurrence with all empty or nil fields and would exit with "Unable to get occurrence id". 
2. getOccurrence required a project id, but was using occurrence id(oPID), so was changed to use nPID.
3. Occurrence name was defaulting to empty string, it is now created with actual name so the created and fetched occurrence can be compared.