### PR TITLE
Fix and update the client lib generation script.

### DIFF
--- a/generation/generate_client_libs.sh
+++ b/generation/generate_client_libs.sh
@@ -1,13 +1,12 @@
-# Download grafeas.swagger.json
-wget https://github.com/grafeas/grafeas/raw/master/v1alpha1/proto/grafeas.swagger.json grafeas.swagger.json
+# Download v1alpha1 grafeas.swagger.json.
+wget https://github.com/grafeas/grafeas/raw/master/v1alpha1/proto/grafeas.swagger.json
 
-# Download swagger-codegen cli tool
-wget https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.4.0-SNAPSHOT/swagger-codegen-cli-2.4.0-20180611.162651-269.jar -O swagger-codegen-cli.jar
+# Download swagger-codegen CLI tool.
+wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O swagger-codegen-cli.jar
 
-# Generate libraries from grafeas.swagger.json
+# Generate libraries from grafeas.swagger.json.
 java -jar ./swagger-codegen-cli.jar generate \
     -i ./grafeas.swagger.json \
     -l go \
     -o ../v1alpha1 \
     -c ./config.go.json \
-


### PR DESCRIPTION
- Fix wget error on downloading grafeas.swagger.json.
- Fix where we get swagger-codegen-cli.jar from. We should get it from Maven as [stated here](swagger-codegen-cli.jar).